### PR TITLE
Bug fix for content type with charset

### DIFF
--- a/codec/json_codec.go
+++ b/codec/json_codec.go
@@ -2,18 +2,29 @@ package codec
 
 import (
 	"encoding/json"
-	"go.nandlabs.io/commons/codec/validator"
 	"io"
+
+	"go.nandlabs.io/commons/codec/validator"
 )
 
 var structValidator = validator.NewStructValidator()
 
 type jsonRW struct {
+	options map[string]interface{}
 }
 
 func (c *jsonRW) Write(v interface{}, w io.Writer) error {
+	//only utf-8 charset is supported
+	var escapeHtml = false
+	if c.options != nil {
+		if v, ok := c.options[JsonEscapeHTML]; ok {
+			escapeHtml = v.(bool)
+		}
 
-	return json.NewEncoder(w).Encode(v)
+	}
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(escapeHtml)
+	return encoder.Encode(v)
 
 }
 

--- a/codec/xml_codec.go
+++ b/codec/xml_codec.go
@@ -2,34 +2,20 @@ package codec
 
 import (
 	"encoding/xml"
-	"errors"
-	"fmt"
 	"io"
-	"io/ioutil"
 )
 
 type xmlRW struct {
+	options map[string]interface{}
 }
 
 func (x *xmlRW) Write(v interface{}, w io.Writer) error {
-	output, err := xml.Marshal(v)
-	if err != nil {
-		return errors.New(fmt.Sprintf("xml marshal error: %d", err))
-	}
-	_, errW := w.Write(output)
-	if errW != nil {
-		return errW
-	}
-	return nil
+	encoder := xml.NewEncoder(w)
+	return encoder.Encode(v)
+
 }
 
 func (x *xmlRW) Read(r io.Reader, v interface{}) error {
-	b, err := ioutil.ReadAll(r)
-	if err != nil {
-		return errors.New(fmt.Sprintf("xml input error: %d", err))
-	}
-	if errU := xml.Unmarshal(b, v); err != nil {
-		return errors.New(fmt.Sprintf("xml unmarshal error: %d", errU))
-	}
-	return nil
+	decoder := xml.NewDecoder(r)
+	return decoder.Decode(v)
 }

--- a/codec/yaml_codec.go
+++ b/codec/yaml_codec.go
@@ -1,36 +1,20 @@
 package codec
 
 import (
-	"errors"
-	"fmt"
-	"io"
-	"io/ioutil"
-
 	"gopkg.in/yaml.v3"
+	"io"
 )
 
 type yamlRW struct {
+	options map[string]interface{}
 }
 
 func (y *yamlRW) Write(v interface{}, w io.Writer) error {
-	output, err := yaml.Marshal(v)
-	if err != nil {
-		return errors.New(fmt.Sprintf("xml marshal error: %d", err))
-	}
-	_, errW := w.Write(output)
-	if errW != nil {
-		return errW
-	}
-	return nil
+	encoder := yaml.NewEncoder(w)
+	return encoder.Encode(v)
 }
 
 func (y *yamlRW) Read(r io.Reader, v interface{}) error {
-	b, err := ioutil.ReadAll(r)
-	if err != nil {
-		return errors.New(fmt.Sprintf("xml input error: %d", err))
-	}
-	if errU := yaml.Unmarshal(b, v); err != nil {
-		return errors.New(fmt.Sprintf("xml unmarshal error: %d", errU))
-	}
-	return nil
+	decoder := yaml.NewDecoder(r)
+	return decoder.Decode(v)
 }


### PR DESCRIPTION
Added json escapeHtml option handing
Fixed the Content-Type header with charset value for codec.go